### PR TITLE
Compilation on archlinux

### DIFF
--- a/src/main/make/Makefile.unix.shared
+++ b/src/main/make/Makefile.unix.shared
@@ -4,7 +4,8 @@ TARGETDIR = ../resources
 $(shell mkdir -p $(TARGETDIR))
 
 #if java home is not set (debian) find java home by searching for javac.
-JNI_HOME ?= $(shell readlink -f /usr/bin/javac | sed "s:/bin/javac::")
+JAVA_HOME ?= $(shell readlink -f /usr/bin/javac | sed "s:/bin/javac::")
+JNI_HOME ?= $(JAVA_HOME)
 
 #The LIBNAME_ARCH and MARCH variable should be set by the makefile that includes this makefile.
 LIBNAME = libxcb4j_$(LIBNAME_ARCH).so


### PR DESCRIPTION
Hello!

On archlinux Oracle java by default located in /opt directory and $JNI_HOME variable is not set. I changed your makefile to prefer $JAVA_HOME location to location found by "readlink".
